### PR TITLE
ci: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,10 +29,6 @@ updates:
           - '*'
   - package-ecosystem: gitsubmodule
     directory: /
-    commit-message:
-      # Prefix with 'fix' to generate patch releases.
-      # dummy update.
-      prefix: fix
     schedule:
       interval: daily
     open-pull-requests-limit: 1


### PR DESCRIPTION
No need to generate fix: prefixed messages since the generated files need to be published manually.