### PR TITLE
chore: group bump to submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
     directory: /
     schedule:
       interval: daily
-    open-pull-requests-limit: 5
     labels:
       - commit-updates
+    groups:
+      all:
+        patterns:
+          - '*'


### PR DESCRIPTION
Open a single PR about rolling the versions, reducing human input.